### PR TITLE
test: add test case for fuzzy-search and config jest to handle fuzzify

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
-}

--- a/__tests__/ReactTags.test.tsx
+++ b/__tests__/ReactTags.test.tsx
@@ -5,8 +5,15 @@ import { spy, stub, createSandbox } from 'sinon';
 import { WithContext as ReactTags } from '../src/index';
 
 import { KEYS, SEPARATORS } from '../src/components/constants';
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  expect as TestingLibraryExpect,
+} from '@testing-library/react';
 import type { Tag } from '../src/components/SingleTag';
+
+import COUNTRIES from '../example/countries';
 
 /* eslint-disable no-console */
 
@@ -1376,6 +1383,140 @@ describe('Test ReactTags', () => {
 
       const { container } = render(<ReactTags classNames={classNames} />);
       jestExpect(container).toMatchSnapshot();
+    });
+  });
+});
+
+describe('Fuzzy Search is enabled ', () => {
+  it('shouldRenderSuggestionsBasedOnFuzzyLogic', () => {
+    const suggestions = COUNTRIES.map((country) => {
+      return {
+        id: country,
+        text: country,
+        className: '',
+      };
+    });
+    const fuzzyResult = [
+      {
+        id: 'Albania',
+        text: 'Albania',
+        className: '',
+      },
+      {
+        id: 'Algeria',
+        text: 'Algeria',
+        className: '',
+      },
+      {
+        id: 'Armenia',
+        text: 'Armenia',
+        className: '',
+      },
+      {
+        id: 'Bolivia',
+        text: 'Bolivia',
+        className: '',
+      },
+      {
+        id: 'Gambia',
+        text: 'Gambia',
+        className: '',
+      },
+      {
+        id: 'Latvia',
+        text: 'Latvia',
+        className: '',
+      },
+      {
+        id: 'Liberia',
+        text: 'Liberia',
+        className: '',
+      },
+      {
+        id: 'Macedonia',
+        text: 'Macedonia',
+        className: '',
+      },
+      {
+        id: 'Malawi',
+        text: 'Malawi',
+        className: '',
+      },
+      {
+        id: 'Malaysia',
+        text: 'Malaysia',
+        className: '',
+      },
+      {
+        id: 'Mali',
+        text: 'Mali',
+        className: '',
+      },
+      {
+        id: 'Malta',
+        text: 'Malta',
+        className: '',
+      },
+      {
+        id: 'Moldova',
+        text: 'Moldova',
+        className: '',
+      },
+      {
+        id: 'Namibia',
+        text: 'Namibia',
+        className: '',
+      },
+      {
+        id: 'Nigeria',
+        text: 'Nigeria',
+        className: '',
+      },
+      {
+        id: 'Palestine',
+        text: 'Palestine',
+        className: '',
+      },
+      {
+        id: 'Russia',
+        text: 'Russia',
+        className: '',
+      },
+      {
+        id: 'Tunisia',
+        text: 'Tunisia',
+        className: '',
+      },
+      {
+        id: 'Zambia',
+        text: 'Zambia',
+        className: '',
+      },
+    ];
+
+    render(
+      <ReactTags
+        tags={[]}
+        suggestions={suggestions}
+        separators={[SEPARATORS.ENTER, SEPARATORS.COMMA]}
+        handleDelete={() => {}}
+        handleAddition={() => {}}
+        handleDrag={() => {}}
+        handleTagClick={() => {}}
+        onTagUpdate={() => {}}
+        inputFieldPosition="bottom"
+        enableFuzzySearch={true}
+        editable
+        clearAll
+        onClearAll={() => {}}
+        maxTags={7}
+        allowAdditionFromPaste
+      />
+    );
+    const queryInput = screen.getByTestId('input') as HTMLInputElement;
+    fireEvent.change(queryInput, { target: { value: 'malesia' } });
+    fuzzyResult.forEach((value) => {
+      expect(screen.getByText(value.text)).to.exist;
     });
   });
 });

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+  ignore: ['/node_modules/(?!fuzzify)/'],
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -103,7 +103,7 @@ module.exports = {
   // A map from regular expressions to module names that allow to stub out resources with a single module
   moduleNameMapper: {
     '\\.(sa|sc|c)ss$': '<rootDir>/__tests__/__mocks__/styleMock.js',
-    "^lodash-es$": "lodash"
+    '^lodash-es$': 'lodash',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
@@ -131,7 +131,7 @@ module.exports = {
   // resetModules: false,
 
   // A path to a custom resolver
-  // resolver: null,
+  // resolver: './customResolver.cjs',
 
   // Automatically restore mock state between every test
   // restoreMocks: false,
@@ -191,6 +191,7 @@ module.exports = {
 
   // A map from regular expressions to paths to transformers
   transform: {
+    '^.+\\.js': 'babel-jest',
     '^.+\\.tsx?$': [
       'ts-jest',
       {
@@ -200,7 +201,7 @@ module.exports = {
   },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: ['/node_modules/'],
+  transformIgnorePatterns: ['/node_modules/(?!fuzzify)'],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -257,6 +257,7 @@ const ReactTags = (props: ReactTagsProps) => {
 
   const updateSuggestions = () => {
     const newSuggestions = filteredSuggestions(query);
+    console.log(newSuggestions);
     setSuggestions(newSuggestions);
     setSelectedIndex(
       selectedIndex >= newSuggestions.length

--- a/webpack-dev-server.config.cjs
+++ b/webpack-dev-server.config.cjs
@@ -46,6 +46,13 @@ const config = {
         exclude: /node_modules/,
       },
       {
+        test: /\.js$/, // All .js files
+        include: [path.resolve(path.dirname, 'node_modules/fuzzify')],
+        use: {
+          loader: 'babel-loader',
+        },
+      },
+      {
         test: /\.(sa|sc|c)ss$/,
         exclude: /node_modules/,
         use: ['style-loader', 'css-loader', 'sass-loader'],
@@ -56,9 +63,9 @@ const config = {
       {
         test: /\.m?js/,
         resolve: {
-          fullySpecified: false
-        }
-      }
+          fullySpecified: false,
+        },
+      },
     ],
   },
   resolve: {


### PR DESCRIPTION
## TEST

- Add test cases for suggestions based on fuzzy distance. 
- Modify `jest-config` to tranform fuzzify while compiling . 
- rename `.babelrc` to `.babel.config.cjs`. as webpack most of the time do not consider `.babelrc` while transpiling or bundling node_modules 